### PR TITLE
#53 3.3 Extra styling on the screeningcards section

### DIFF
--- a/src/components/ScreeningCard.jsx
+++ b/src/components/ScreeningCard.jsx
@@ -30,9 +30,11 @@ export default function ScreeningCards() {
             <a href={`/booking/${item._id}`}>
               <div className="screeningcard__container">
                 <p className="screeningcard__title">{item.movie?.title}</p>
-                <p>{`Salong ${item.room.name}`}</p>
-                <p>{new Date(item.date).toLocaleDateString('sv-SE')}</p>
-                <p>{new Date(item.date).toLocaleTimeString('sv-SE', { hour: '2-digit', minute: '2-digit' })}</p>
+                <p className="screeningcard__room">{`Salong ${item.room.name}`}</p>
+                <p className="screeningcard__date">{new Date(item.date).toLocaleDateString('sv-SE')}</p>
+                <p className="screeningcard__time">
+                  {new Date(item.date).toLocaleTimeString('sv-SE', { hour: '2-digit', minute: '2-digit' })}
+                </p>
               </div>
             </a>
           </li>

--- a/src/styles/ScreeningCard.scss
+++ b/src/styles/ScreeningCard.scss
@@ -94,9 +94,5 @@
     .screeningcard__container {
       width: 100%;
     }
-
-    .screeningcard__header {
-      width: 40%;
-    }
   }
 }

--- a/src/styles/ScreeningCard.scss
+++ b/src/styles/ScreeningCard.scss
@@ -3,20 +3,27 @@
   justify-content: center;
   margin: 0;
   width: 47rem;
-  height: 20rem;
+  height: 19rem;
   padding-bottom: 2rem;
 }
 
+.screeningcard__container {
+  width: 16rem;
+}
+
 .screeningcard__title {
+  text-align: center;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 10rem;
-  max-height: 5rem;
+  background-color: #1f4163;
+  font-size: 1.2rem;
+  padding: 0rem 1rem;
 }
 
 .screeningcard__list {
   display: flex;
+  text-align: center;
   gap: 2rem;
   list-style: none;
   overflow-x: scroll;
@@ -24,17 +31,16 @@
   border-radius: 10px;
   padding-right: 2rem;
   width: 100%;
+  outline: 2px solid #bbb;
 
   li {
+    outline: 1px solid #fff;
+    box-shadow: 0px 0px 4px 0px #333;
     margin-top: 1.8rem;
-    max-height: 80%;
+    height: 200px;
     border-radius: 10px;
-    min-width: 12rem;
-    max-width: 12rem;
-    background-color: #012840;
+    background-color: #1f4163;
     color: #ffffff;
-    font-size: larger;
-    padding-left: 2rem;
     font-weight: 600;
 
     a {
@@ -48,6 +54,24 @@
     transform: translateY(-10px);
     box-shadow: 0 8px 16px rgba(0, 0, 0, 0.4);
   }
+}
+
+.screeningcard__room,
+.screeningcard__date,
+.screeningcard__time {
+  background-color: #03658c;
+  margin: 2px 2px;
+  padding: 0.77rem;
+  height: 20px;
+}
+
+.screeningcard__time {
+  border-radius: 0px 0px 10px 10px;
+  font-family: Georgia, 'Times New Roman', Times, serif;
+}
+
+.screeningcard__date {
+  font-family: Georgia, 'Times New Roman', Times, serif;
 }
 
 @media screen and (max-width: 800px) {
@@ -67,13 +91,12 @@
     padding-bottom: 2rem;
     width: 13rem;
 
-    li {
-      margin-left: -0.5rem;
-      padding-left: 1rem;
+    .screeningcard__container {
+      width: 100%;
     }
-  }
 
-  .screeningcard__header {
-    text-align: center;
+    .screeningcard__header {
+      width: 40%;
+    }
   }
 }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -73,4 +73,9 @@ body {
     min-width: auto;
     width: 100%;
   }
+
+  .screeningcard__header {
+    width: 80%;
+    text-align: center;
+  }
 }


### PR DESCRIPTION
## Pull Request Type

Please check the type of change your PR introduces:

- [ ] Feature (a new feature for the project)
- [ ] Fix (a bug fix)
- [ ] Chore (updating grunt tasks etc; no production code change)
- [ ] Refactor (refactoring production code)
- [ ] Docs (changes to the documentation)
- [ ] Style (formatting, missing semi colons, etc; no production code change)
- [ ] Test (adding missing tests, refactoring tests; no production code change)

## Description
Just a little different styling to make it a little more exiting and differ a bit more from the moviecards above.
I have used the same blue colors as on the rest of the site.

## Motivation and Context
To make the section more distinct, less monotonous and easier to read.

## How Has This Been Tested?
Manually tested in desktop and mobile view.

## Screenshots (if appropriate):
![screeningsection](https://github.com/user-attachments/assets/f9c6c1c3-040f-4a33-a919-5ebffe5c3014)

---

![screeningsectionmobile](https://github.com/user-attachments/assets/c9fb8b3a-b784-4a1b-b89e-ff47504a9e15)


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have named this PR according to following naming convention: #[issue-number] PR description

## Additional Information:

[Add any other information about the PR here]

## Related Issues:

[Link any related issues here]
